### PR TITLE
Fix color_picking bug added with PR #42

### DIFF
--- a/src/ColorPicking/ColorPicking.cxx
+++ b/src/ColorPicking/ColorPicking.cxx
@@ -119,19 +119,19 @@ void ColorPicking::initBuffers(){
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
-void ColorPicking::resizeBuffers(GLuint width, GLuint height){
+void ColorPicking::resizeBuffers(GLuint newWidth, GLuint newHeight){
   // If the resize is a shrinking of the screen, then don't do anything because
   // the buffer will do the job
-  if(width >= width and height >= height){
-    width = width;
-    height = height;
+  if(width >= newWidth and height >= newHeight){
+    width = newWidth;
+    height = newHeight;
 
     return;
   };
 
   // Change the size for the buffers
-  width = width;
-  height = height;
+  width = newWidth;
+  height = newHeight;
 
   deleteBuffers();
 

--- a/src/ColorPicking/ColorPicking.hxx
+++ b/src/ColorPicking/ColorPicking.hxx
@@ -45,7 +45,7 @@ public:
     \param width The screen width
     \param height The screen height
   */
-  void resizeBuffers(GLuint width, GLuint height);
+  void resizeBuffers(GLuint newWidth, GLuint newHeight);
 
   /* Get the cliked piece position according to the clicked pixel on the screen.
     This will perform a rendering in the framebuffer


### PR DESCRIPTION
Due to PR #42, there was no difference between the attribute "width" of the ColorPicking class and the argument "width" of its resizeBuffers method.